### PR TITLE
Minor change to modtran config comparisons

### DIFF
--- a/isofit/radiative_transfer/modtran.py
+++ b/isofit/radiative_transfer/modtran.py
@@ -350,13 +350,13 @@ class ModtranRT(RadiativeTransferEngine):
             with open(infilepath, "r") as f:
                 current_config = json.load(f)["MODTRAN"]
 
-            parts = 1  # Number of parts to the config
-            reset = (
-                [  # Tuples to a config option, ie. config[part]['MODTRANINPUT'][*keys]
-                    ("NAME",),
-                    ("SPECTRAL", "FILTNM"),
-                ]
-            )
+            # Number of parts to the config
+            parts = 1
+            reset = [
+                # Tuples to a config option, ie. config[part]['MODTRANINPUT'][*keys]
+                ("NAME",),
+                ("SPECTRAL", "FILTNM"),
+            ]
             if self.multipart_transmittance:
                 parts += 2
                 reset += [


### PR DESCRIPTION
Per request https://github.com/isofit/isofit/pull/521#discussion_r1703176579

Tested:
```python
modtran_config = [
    {
    'MODTRANINPUT': {'NAME': 'ABC',
    'SPECTRAL': {'FILTNM': 'ABC'},
    'AEROSOLS': {'IREGSPC': [{'EXTC': 'ABC', 'ABSC': 'ABC'}]}}
    },
    {
    'MODTRANINPUT': {'NAME': 'ABC',
    'SPECTRAL': {'FILTNM': 'ABC'},
    'AEROSOLS': {'IREGSPC': [{'EXTC': 'ABC', 'ABSC': 'ABC'}]}}
    },
    {
    'MODTRANINPUT': {'NAME': 'ABC',
    'SPECTRAL': {'FILTNM': 'ABC'},
    'AEROSOLS': {'IREGSPC': [{'EXTC': 'ABC', 'ABSC': 'ABC'}]}}
    },
]

current_config = [
    {
    'MODTRANINPUT': {'NAME': 'XYZ',
    'SPECTRAL': {'FILTNM': 'XYZ'},
    'AEROSOLS': {'IREGSPC': [{'EXTC': 'XYZ', 'ABSC': 'XYZ'}]}}
    },
    {
    'MODTRANINPUT': {'NAME': 'XYZ',
    'SPECTRAL': {'FILTNM': 'XYZ'},
    'AEROSOLS': {'IREGSPC': [{'EXTC': 'XYZ', 'ABSC': 'XYZ'}]}}
    },
    {
    'MODTRANINPUT': {'NAME': 'XYZ',
    'SPECTRAL': {'FILTNM': 'XYZ'},
    'AEROSOLS': {'IREGSPC': [{'EXTC': 'XYZ', 'ABSC': 'XYZ'}]}}
    },
]

multipart_transmittance = True

parts = 1
reset = [
    ('NAME',),
    ('SPECTRAL', 'FILTNM'),
]
if multipart_transmittance:
    parts += 2
    reset += [
        ('AEROSOLS', 'IREGSPC', 0, 'EXTC'),
        ('AEROSOLS', 'IREGSPC', 0, 'ABSC')
    ]

# Reset the keys to an empty string
for config in (modtran_config, current_config):
    for i in range(parts):
        sub = config[i]['MODTRANINPUT']
        for keys in reset:
            opt = sub
            for key in keys[:-1]:
                opt = opt[key]
            opt[keys[-1]] = ''
            
print(modtran_config)
[{'MODTRANINPUT': {'NAME': '',
   'SPECTRAL': {'FILTNM': ''},
   'AEROSOLS': {'IREGSPC': [{'EXTC': '', 'ABSC': ''}]}}},
 {'MODTRANINPUT': {'NAME': '',
   'SPECTRAL': {'FILTNM': ''},
   'AEROSOLS': {'IREGSPC': [{'EXTC': '', 'ABSC': ''}]}}},
 {'MODTRANINPUT': {'NAME': '',
   'SPECTRAL': {'FILTNM': ''},
   'AEROSOLS': {'IREGSPC': [{'EXTC': '', 'ABSC': ''}]}}}]

print(current_config)
[{'MODTRANINPUT': {'NAME': '',
   'SPECTRAL': {'FILTNM': ''},
   'AEROSOLS': {'IREGSPC': [{'EXTC': '', 'ABSC': ''}]}}},
 {'MODTRANINPUT': {'NAME': '',
   'SPECTRAL': {'FILTNM': ''},
   'AEROSOLS': {'IREGSPC': [{'EXTC': '', 'ABSC': ''}]}}},
 {'MODTRANINPUT': {'NAME': '',
   'SPECTRAL': {'FILTNM': ''},
   'AEROSOLS': {'IREGSPC': [{'EXTC': '', 'ABSC': ''}]}}}]
```